### PR TITLE
Feat/Move API key to env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,2 @@
 # Get your Groq API Key here: https://console.groq.com/keys
 GROQ_API_KEY=XXXXXXXX
-
-# Generate a random secret: https://generate-secret.vercel.app/32 or `openssl rand -base64 32`
-AUTH_SECRET=XXXXXXXX
-
-# Instructions to create kv database here: https://vercel.com/docs/storage/vercel-kv/quickstart and 
-KV_URL=XXXXXXXX
-KV_REST_API_URL=XXXXXXXX
-KV_REST_API_TOKEN=XXXXXXXX
-KV_REST_API_READ_ONLY_TOKEN=XXXXXXXX

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,17 +1,13 @@
 'use server'
 
-import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import { kv } from '@vercel/kv'
-
-import { type Chat } from '@/lib/types'
 
 export async function refreshHistory(path: string) {
   redirect(path)
 }
 
 export async function getMissingKeys() {
-  const keysRequired: string[] = [] //GROQ_API_KEY
+  const keysRequired: string[] = ['GROQ_API_KEY']
   return keysRequired
     .map(key => (process.env[key] ? '' : key))
     .filter(key => key !== '')

--- a/components/api-key-input.tsx
+++ b/components/api-key-input.tsx
@@ -1,18 +1,32 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { EyeOpenIcon, EyeNoneIcon } from '@radix-ui/react-icons'
 import { useLocalStorage } from '@/lib/hooks/use-local-storage'
+import { getMissingKeys } from '@/app/actions'
 
 export function ApiKeyInput() {
+  const [missingKeys, setMissingKeys] = useState<string[]>([])
+
+  useEffect(() => {
+    async function fetchMissingKeys() {
+      const keys = await getMissingKeys()
+      setMissingKeys(keys)
+    }
+    fetchMissingKeys()
+  }, [])
+
+  if (!missingKeys.includes("GROQ_API_KEY")){
+    return null
+  }
   const [apiKey, setApiKey] = useLocalStorage('groqKey', '')
   const [isVisible, setIsVisible] = useState(false)
 
   const toggleVisibility = () => setIsVisible(!isVisible)
 
   return (
-    <div className="mx-auto w-full">
+    <div className="mx-auto w-full mt-6">
       <div className="space-y-1">
         <div className="flex justify-between items-center">
           <Label htmlFor="apiKey">Enter your Groq API Key:</Label>

--- a/components/api-key-input.tsx
+++ b/components/api-key-input.tsx
@@ -8,7 +8,9 @@ import { getMissingKeys } from '@/app/actions'
 
 export function ApiKeyInput() {
   const [missingKeys, setMissingKeys] = useState<string[]>([])
-
+  const [apiKey, setApiKey] = useLocalStorage('groqKey', '')
+  const [isVisible, setIsVisible] = useState(false)
+  
   useEffect(() => {
     async function fetchMissingKeys() {
       const keys = await getMissingKeys()
@@ -20,8 +22,6 @@ export function ApiKeyInput() {
   if (!missingKeys.includes("GROQ_API_KEY")){
     return null
   }
-  const [apiKey, setApiKey] = useLocalStorage('groqKey', '')
-  const [isVisible, setIsVisible] = useState(false)
 
   const toggleVisibility = () => setIsVisible(!isVisible)
 

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -64,7 +64,7 @@ export function Chat({ id, className, session, missingKeys }: ChatProps) {
       className="group w-full overflow-auto pl-0 peer-[[data-state=open]]:lg:pl-[250px] peer-[[data-state=open]]:xl:pl-[300px]"
       ref={scrollRef}
     >
-      {messages.length ? <MissingApiKeyBanner /> : <TickerTape />}
+      {messages.length ? <MissingApiKeyBanner missingKeys={missingKeys} /> : <TickerTape />}
 
       <div
         className={cn(

--- a/components/empty-screen.tsx
+++ b/components/empty-screen.tsx
@@ -28,7 +28,6 @@ export function EmptyScreen() {
             </ExternalLink>
           </span>
         </p>
-        <div className="mb-6"></div>
         <ApiKeyInput />
       </div>
     </div>

--- a/components/missing-api-key-banner.tsx
+++ b/components/missing-api-key-banner.tsx
@@ -5,11 +5,15 @@ import Image from 'next/image'
 import { useLocalStorage } from '@/lib/hooks/use-local-storage'
 import { Button, buttonVariants } from '@/components/ui/button'
 
-export function MissingApiKeyBanner() {
+export function MissingApiKeyBanner({ missingKeys }: { missingKeys: string[] }) {
   const [apiKey, setApiKey] = useLocalStorage('groqKey', '')
 
   if (apiKey.length > 0) {
-    return <></>
+    return null
+  }
+
+  if (!missingKeys.includes("GROQ_API_KEY")){
+    return null
   }
 
   return (

--- a/lib/chat/actions.tsx
+++ b/lib/chat/actions.tsx
@@ -44,16 +44,17 @@ interface MutableAIState {
 
 const MODEL = 'llama3-70b-8192'
 const TOOL_MODEL = 'llama3-70b-8192'
+const GROQ_API_KEY_ENV = process.env.GROQ_API_KEY;
 
 async function generateCaption(
   symbol: string,
   toolName: string,
   aiState: MutableAIState,
-  groqApiKey: string
+  groqApiKeyLocal: string
 ): Promise<string> {
   const groq = createOpenAI({
     baseURL: 'https://api.groq.com/openai/v1',
-    apiKey: groqApiKey
+    apiKey: GROQ_API_KEY_ENV ?? groqApiKeyLocal
   })
 
   aiState.update({
@@ -143,7 +144,7 @@ Besides the symbol, you cannot customize any of the screeners or graphics. Do no
   }
 }
 
-async function submitUserMessage(content: string, groqApiKey: string) {
+async function submitUserMessage(content: string, groqApiKeyLocal: string) {
   'use server'
 
   const aiState = getMutableAIState<typeof AI>()
@@ -166,7 +167,7 @@ async function submitUserMessage(content: string, groqApiKey: string) {
   try {
     const groq = createOpenAI({
       baseURL: 'https://api.groq.com/openai/v1',
-      apiKey: groqApiKey
+      apiKey: GROQ_API_KEY_ENV ?? groqApiKeyLocal
     })
 
     const result = await streamUI({
@@ -274,7 +275,7 @@ Assistant (you): { "tool_call": { "id": "pending", "type": "function", "function
               symbol,
               'showStockChart',
               aiState,
-              (groqApiKey = groqApiKey)
+              (groqApiKeyLocal = groqApiKeyLocal)
             )
 
             return (
@@ -338,7 +339,7 @@ Assistant (you): { "tool_call": { "id": "pending", "type": "function", "function
               symbol,
               'showStockPrice',
               aiState,
-              (groqApiKey = groqApiKey)
+              (groqApiKeyLocal = groqApiKeyLocal)
             )
 
             return (
@@ -403,7 +404,7 @@ Assistant (you): { "tool_call": { "id": "pending", "type": "function", "function
               symbol,
               'StockFinancials',
               aiState,
-              (groqApiKey = groqApiKey)
+              (groqApiKeyLocal = groqApiKeyLocal)
             )
 
             return (
@@ -468,7 +469,7 @@ Assistant (you): { "tool_call": { "id": "pending", "type": "function", "function
               symbol,
               'showStockNews',
               aiState,
-              (groqApiKey = groqApiKey)
+              (groqApiKeyLocal = groqApiKeyLocal)
             )
 
             return (
@@ -526,7 +527,7 @@ Assistant (you): { "tool_call": { "id": "pending", "type": "function", "function
               'Generic',
               'showStockScreener',
               aiState,
-              (groqApiKey = groqApiKey)
+              (groqApiKeyLocal = groqApiKeyLocal)
             )
 
             return (
@@ -583,7 +584,7 @@ Assistant (you): { "tool_call": { "id": "pending", "type": "function", "function
               'Generic',
               'showMarketOverview',
               aiState,
-              (groqApiKey = groqApiKey)
+              (groqApiKeyLocal = groqApiKeyLocal)
             )
 
             return (
@@ -640,7 +641,7 @@ Assistant (you): { "tool_call": { "id": "pending", "type": "function", "function
               'Generic',
               'showMarketHeatmap',
               aiState,
-              (groqApiKey = groqApiKey)
+              (groqApiKeyLocal = groqApiKeyLocal)
             )
 
             return (
@@ -697,7 +698,7 @@ Assistant (you): { "tool_call": { "id": "pending", "type": "function", "function
               'Generic',
               'showETFHeatmap',
               aiState,
-              (groqApiKey = groqApiKey)
+              (groqApiKeyLocal = groqApiKeyLocal)
             )
 
             return (
@@ -754,7 +755,7 @@ Assistant (you): { "tool_call": { "id": "pending", "type": "function", "function
               'Generic',
               'showTrendingStocks',
               aiState,
-              (groqApiKey = groqApiKey)
+              (groqApiKeyLocal = groqApiKeyLocal)
             )
 
             return (


### PR DESCRIPTION
Add ability to load and use Groq API key from env variables

Update env example to accurate variables (just GROQ API key), hide api
key input from frontend if key provided in env, and use env key if it
exists instead of the local key.